### PR TITLE
Update var.py

### DIFF
--- a/var.py
+++ b/var.py
@@ -74,8 +74,8 @@ private_dict = {
 }
 
 platform_dict = {
-    Platform.qu_id.value: "渠道服",
-    Platform.tw_id.value: "台服",
+    Platform.qu_id.value: "渠",
+    Platform.tw_id.value: "台",
     "渠": Platform.qu_id.value,
     "台": Platform.tw_id.value
 }


### PR DESCRIPTION
系统帮助调用platform id时，会调用platform_dict的全名，比如指令变成了台服竞技场查询，这样系统无法接受，只能改缩写了。